### PR TITLE
Header modifying

### DIFF
--- a/src/ts/actions.ts
+++ b/src/ts/actions.ts
@@ -6,14 +6,14 @@ import {
   RequestStates,
   UrlMethod,
 } from './types';
-import { apiRequest, metaWithResponse } from './utils';
+import { apiRequest } from './utils';
 
 export const REQUEST_STATE = 'REQUEST_STATE';
 export function setRequestState(
   actionSet: AsyncActionSet,
   requestState: RequestStates,
   data: any,
-  tag?: string
+  tag: string = ''
 ) {
   return {
     payload: {
@@ -27,7 +27,7 @@ export function setRequestState(
 }
 
 export const RESET_REQUEST_STATE = 'RESET_REQUEST_STATE';
-export function resetRequestState(actionSet: AsyncActionSet, tag?: string) {
+export function resetRequestState(actionSet: AsyncActionSet, tag: string = '') {
   return {
     payload: {
       actionSet,
@@ -42,8 +42,8 @@ export function dispatchGenericRequest(
   url: string,
   method: UrlMethod,
   data?: any,
-  tag?: string,
-  metaData: RequestMetaData = {},
+  tag: string = '',
+  metaData: Partial<RequestMetaData> = {},
   headers: Dict<string> = {}
 ) {
   return (dispatch: Dispatch<any>) => {
@@ -57,7 +57,7 @@ export function dispatchGenericRequest(
         dispatch({
           type: actionSet.SUCCESS,
           payload: response,
-          meta: metaWithResponse(meta, response),
+          meta,
         });
         dispatch(setRequestState(actionSet, 'SUCCESS', response, tag));
         return response;
@@ -66,7 +66,7 @@ export function dispatchGenericRequest(
         dispatch({
           type: actionSet.FAILURE,
           payload: error,
-          meta: metaWithResponse(meta, error),
+          meta,
           error: true,
         });
         dispatch(setRequestState(actionSet, 'FAILURE', error, tag));

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -5,14 +5,9 @@ export type Dict<T> = Readonly<{ [key: string]: T }>;
 export type RequestStates = 'REQUEST' | 'SUCCESS' | 'FAILURE';
 export type UrlMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS' | 'PATCH';
 
-export interface RequestMetaData {
-  tag?: string;
-  itemId?: string;
-  subgroup?: string;
-  shouldAppend?: boolean;
-  ordering?: string;
-  response?: AxiosResponse<any>;
-}
+export type RequestMetaData = {
+  readonly tag: string;
+} & Dict<any>;
 
 export type AsyncActionSet = Readonly<{
   FAILURE: string;

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,10 +1,9 @@
-import { AxiosError, AxiosPromise, AxiosResponse, default as axios } from 'axios';
+import { AxiosError, AxiosPromise, default as axios } from 'axios';
 import * as Cookies from 'js-cookie';
 import * as path from 'path';
 import {
   AsyncActionSet,
   Dict,
-  RequestMetaData,
   ResponsesReducerState,
   ResponseState,
   UrlMethod,
@@ -87,26 +86,6 @@ export function apiRequest(
     ...config,
     data,
   });
-}
-
-function isResponse(response?: any): response is AxiosResponse {
-  return (
-    typeof response === 'object' &&
-    response.hasOwnProperty('data') &&
-    response.hasOwnProperty('status') &&
-    response.hasOwnProperty('config')
-  );
-}
-
-export function metaWithResponse(
-  meta: RequestMetaData,
-  response?: AxiosResponse
-) {
-  if (!isResponse(response)) {
-    return meta;
-  }
-
-  return { ...meta, response };
 }
 
 function getResponseState(


### PR DESCRIPTION
Some apps need to send various bonus headers; this allows that.

* Removed an unused key from the ApiRequest method, and added the ability to override headers
* Meta can now contain arbitrary data