### PR TITLE
Fix exported import paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Library for simple redux requests",
   "main": "dist/js/index.js",
   "directories": {},

--- a/src/ts/actions.ts
+++ b/src/ts/actions.ts
@@ -1,3 +1,4 @@
+import { AxiosError, AxiosResponse } from 'axios';
 import { Dispatch } from 'redux';
 import {
   AsyncActionSet,
@@ -53,7 +54,7 @@ export function dispatchGenericRequest(
     dispatch(setRequestState(actionSet, 'REQUEST', null, tag));
 
     return apiRequest(url, method, data, headers)
-      .then(response => {
+      .then((response: AxiosResponse) => {
         dispatch({
           type: actionSet.SUCCESS,
           payload: response,
@@ -62,7 +63,7 @@ export function dispatchGenericRequest(
         dispatch(setRequestState(actionSet, 'SUCCESS', response, tag));
         return response;
       })
-      .catch(error => {
+      .catch((error: AxiosError) => {
         dispatch({
           type: actionSet.FAILURE,
           payload: error,

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosPromise, default as axios } from 'axios';
+import axios, { AxiosError, AxiosPromise } from 'axios';
 import * as Cookies from 'js-cookie';
 import * as path from 'path';
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "pretty": true,
     "jsx": "react",
     "target": "es5",
+    "module": "commonjs",
     "lib": [
       "es5",
       "dom",


### PR DESCRIPTION
For some reason the typescript compiler used a dynamic import relative to my local directories for a type that was required in actions, but not imported.

TypeScript used to warn about this (proven in 2.7), but it seems that 2.9 does not.

So the published code contained...

<img width="523" alt="screen shot 2018-10-10 at 18 31 36" src="https://user-images.githubusercontent.com/5850625/46754602-c5d73980-ccba-11e8-929c-9bbbf32f65de.png">

...super weird.

Importing `AxiosResponse, AxiosError` fixed this.

I also improved another couple of import / export related things.