### PR TITLE
Nicer Request action dispatching

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,29 +42,40 @@ const GET_USER = makeAsyncActionSet('GET_USER');
 */
 ```
 
-Launching an action is as simple as calling `dispatchGenericRequest`, with the actionset as the first argument, then the URL, then the method, and then the data.
+Launching an action is as simple as calling `request`, with the actionset as the first argument, then the URL, then the method, and then the data.
 
 This returns a thunk action, and should be returned from an action creator, as below.
 
 ```typescript
 const getUser = (data) => {
-  return dispatchGenericRequest(GET_USER, '/api/user/', 'GET', data);
+  return request(GET_USER, '/api/user/', 'GET', data);
 };
 ```
 
-There are also three optional arguments to `dispatchGenericRequest`:
+`request` also takes an additional argument - a dictionary with the following optional keys:
 
 * `tag` - for name-spacing requests if you plan to make multiple calls to the same point with different parameters.
-* `meta` - for storing additional data about the request that will not be forwarded to the server.
+* `metaData` - for storing additional data about the request that will not be forwarded to the server.
 * `headers` - for allowing the setting of custom headers on the request.
+* `shouldRethrow` - a callback that takes the error object, and can return `true` if you want the Promise to fail instead of digest the error.
 
 ```typescript
 const getUser = (data) => {
-  return dispatchGenericRequest(GET_USER, '/api/user/', 'GET', data, 'users-list', undefined, {Authorization: TOKEN});
+  return request(GET_USER, '/api/user/', 'GET', data, {
+    tag: 'users-list',
+    headers: {Authorization: TOKEN}
+  });
 };
 ```
 
 Once launched, individual actions for `REQUEST`, `SUCCESS` and `FAILURE` will be dispatched, as well as actions to control the `REQUEST_STATE`, which is consumed by `responsesReducer`, should you choose to use it.
+
+Internally, `request` uses a function called `requestFromFunction`, which instead wraps a callback that produces an Axios request.  You can use this in advance cases, if you need finer-grained control over how the request is made.
+
+```typescript
+request(GET_USER, () => axios({ /* some config */}), additionalConfig);
+```
+
 
 ### Keeping track of request states and errors
 

--- a/src/ts/actions.ts
+++ b/src/ts/actions.ts
@@ -84,13 +84,7 @@ export function request(
   method: UrlMethod,
   params: RequestParams = {}
 ) {
-  const {
-    headers,
-    data,
-    metaData,
-    tag,
-    shouldRethrow,
-  } = params;
+  const { headers, data, metaData, tag, shouldRethrow } = params;
 
   return (dispatch: Dispatch<any>) => {
     const meta: RequestMetaData = { ...(metaData || {}), tag: tag || '' };
@@ -98,8 +92,8 @@ export function request(
     dispatch({ type: actionSet.REQUEST, meta });
     dispatch(setRequestState(actionSet, 'REQUEST', null, tag || ''));
 
-    return apiRequest(url, method, data, headers || {})
-      .then((response: AxiosResponse) => {
+    return apiRequest(url, method, data, headers || {}).then(
+      (response: AxiosResponse) => {
         dispatch({
           type: actionSet.SUCCESS,
           payload: response,
@@ -107,8 +101,8 @@ export function request(
         });
         dispatch(setRequestState(actionSet, 'SUCCESS', response, tag || ''));
         return response;
-      })
-      .catch((error: AxiosError) => {
+      },
+      (error: AxiosError) => {
         dispatch({
           type: actionSet.FAILURE,
           payload: error,
@@ -121,6 +115,7 @@ export function request(
           return Promise.reject(error);
         }
         return Promise.resolve();
-      });
+      }
+    );
   };
 }

--- a/src/ts/actions.ts
+++ b/src/ts/actions.ts
@@ -40,49 +40,10 @@ export function resetRequestState(actionSet: AsyncActionSet, tag: string = '') {
   };
 }
 
-// THIS FUNCTION IS DEPRECATED
-export function dispatchGenericRequest(
-  actionSet: AsyncActionSet,
-  url: string,
-  method: UrlMethod,
-  data?: any,
-  tag: string = '',
-  metaData: Partial<RequestMetaData> = {},
-  headers: Dict<string> = {}
-) {
-  return (dispatch: Dispatch<any>) => {
-    const meta: RequestMetaData = { ...metaData, tag };
-
-    dispatch({ type: actionSet.REQUEST, meta });
-    dispatch(setRequestState(actionSet, 'REQUEST', null, tag));
-
-    return apiRequest(url, method, data, headers)
-      .then((response: AxiosResponse) => {
-        dispatch({
-          type: actionSet.SUCCESS,
-          payload: response,
-          meta,
-        });
-        dispatch(setRequestState(actionSet, 'SUCCESS', response, tag));
-        return response;
-      })
-      .catch((error: AxiosError) => {
-        dispatch({
-          type: actionSet.FAILURE,
-          payload: error,
-          meta,
-          error: true,
-        });
-        dispatch(setRequestState(actionSet, 'FAILURE', error, tag));
-        return Promise.reject(error);
-      });
-  };
-}
-
-export function requestFromFunction (
+export function requestFromFunction(
   actionSet: AsyncActionSet,
   requestBuilder: () => AxiosPromise,
-  params: RequestParams = {},
+  params: RequestParams = {}
 ) {
   const { metaData, tag, shouldRethrow } = params;
 

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,6 +1,7 @@
 export {
+  request,
   REQUEST_STATE,
-  dispatchGenericRequest,
+  requestFromFunction,
   RESET_REQUEST_STATE,
   resetRequestState,
 } from './actions';

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -33,10 +33,13 @@ export type ResetRequestStatePayload = Readonly<{
   tag?: string;
 }>;
 
-export type RequestParams = Readonly<{
-  tag?: string;
-  metaData?: Partial<RequestMetaData>;
-  data?: string | number | Dict<any> | ReadonlyArray<any>;
-  headers?: Dict<string>;
+export interface RequestParams {
+  readonly tag?: string;
+  readonly metaData?: Partial<RequestMetaData>;
+  readonly headers?: Dict<string>;
   shouldRethrow?(errors: AxiosError): boolean;
-}>;
+};
+
+export interface ExtendedRequestParams extends RequestParams {
+  readonly headers?: Dict<string>;
+}

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -38,7 +38,7 @@ export interface RequestParams {
   readonly metaData?: Partial<RequestMetaData>;
   readonly headers?: Dict<string>;
   shouldRethrow?(errors: AxiosError): boolean;
-};
+}
 
 export interface ExtendedRequestParams extends RequestParams {
   readonly headers?: Dict<string>;

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -34,9 +34,9 @@ export type ResetRequestStatePayload = Readonly<{
 }>;
 
 export type RequestParams = Readonly<{
-  tag?: string
-  metaData?: Partial<RequestMetaData>,
-  data?: string | number | Dict<any> | ReadonlyArray<any>,
-  headers?: Dict<string>,
-  shouldRethrow?(errors: AxiosError): boolean,
+  tag?: string;
+  metaData?: Partial<RequestMetaData>;
+  data?: string | number | Dict<any> | ReadonlyArray<any>;
+  headers?: Dict<string>;
+  shouldRethrow?(errors: AxiosError): boolean;
 }>;

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -32,3 +32,11 @@ export type ResetRequestStatePayload = Readonly<{
   actionSet: AsyncActionSet;
   tag?: string;
 }>;
+
+export type RequestParams = Readonly<{
+  tag?: string
+  metaData?: Partial<RequestMetaData>,
+  data?: string | number | Dict<any> | ReadonlyArray<any>,
+  headers?: Dict<string>,
+  shouldRethrow?(errors: AxiosError): boolean,
+}>;


### PR DESCRIPTION
This swaps out dispatchGenericRequest for a much simpler 'request' method, plus 'requestFromFunction' for those wanting finer grained control over how the API is hit.

In addition, by default the API will now swallow HTTP errors; you can pass a function to mark when to rethrow errors.

TODO: Update the README