### PR TITLE
fix for React Native GET requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Library for simple redux requests",
   "main": "dist/js/index.js",
   "directories": {},

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -68,7 +68,7 @@ export function apiRequest(options: AxiosRequestConfig): AxiosPromise {
     ...options,
     url: myPath,
     headers: combinedHeaders,
-    data: options.data || {},
+    data: options.data || undefined,
   };
 
   // Axios uses a different key for sending data on a GET request

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -68,13 +68,14 @@ export function apiRequest(options: AxiosRequestConfig): AxiosPromise {
     ...options,
     url: myPath,
     headers: combinedHeaders,
-    data: options.data || undefined,
+    data: options.data || {},
   };
 
   // Axios uses a different key for sending data on a GET request
   if (options.method === 'GET') {
+    const { data, ...getConfig } = config;
     return axios({
-      ...config,
+      ...getConfig,
       params: config.data,
     });
   }

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -76,7 +76,7 @@ export function apiRequest(options: AxiosRequestConfig): AxiosPromise {
     const { data, ...getConfig } = config;
     return axios({
       ...getConfig,
-      params: config.data,
+      params: data,
     });
   }
   return axios(config);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -621,7 +621,7 @@ describe('Requests', () => {
         method: 'GET',
       });
       const params = (myRequest as any).params;
-      expect(params.params).toEqual(undefined);
+      expect(params.params).toEqual({});
       expect(params.headers).not.toBeUndefined();
     });
 
@@ -639,7 +639,7 @@ describe('Requests', () => {
         method: 'POST',
       });
       const params = (myRequest as any).params;
-      expect(params.data).toEqual(undefined);
+      expect(params.data).toEqual({});
       expect(params.headers).not.toBeUndefined();
     });
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -621,7 +621,7 @@ describe('Requests', () => {
         method: 'GET',
       });
       const params = (myRequest as any).params;
-      expect(params.params).toEqual({});
+      expect(params.params).toEqual(undefined);
       expect(params.headers).not.toBeUndefined();
     });
 
@@ -639,7 +639,7 @@ describe('Requests', () => {
         method: 'POST',
       });
       const params = (myRequest as any).params;
-      expect(params.data).toEqual({});
+      expect(params.data).toEqual(undefined);
       expect(params.headers).not.toBeUndefined();
     });
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -623,6 +623,7 @@ describe('Requests', () => {
       const params = (myRequest as any).params;
       expect(params.params).toEqual({});
       expect(params.headers).not.toBeUndefined();
+      expect(params).not.toHaveProperty('data');
     });
 
     it('should not modify url if not provided', () => {
@@ -653,6 +654,7 @@ describe('Requests', () => {
       const params = (myRequest as any).params;
       expect(params.params).toEqual({ a: 1 });
       expect(params.headers.b).toBe(2);
+      expect(params).not.toHaveProperty('data');
     });
 
     it('should carry forward our provided data - POST', () => {


### PR DESCRIPTION
Fixes an issue with React Native GET requests where sending a config `data: {}` doesn't send the request. Stripping out the `data` key from the config works