### PR TITLE
Dependency and ignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 /node_modules/*
 /coverage/*
 /dist/*
+/.vscode/*
 
 .DS_Store
 .npm-debug.log*
-
-.vscode/*

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,7 @@
+/node_modules/*
+/coverage/*
 !/dist/*
+/.vscode/*
+
+.DS_Store
+.npm-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Library for simple redux requests",
   "main": "dist/js/index.js",
   "directories": {},

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "flux-standard-action": "^1.2.0",
     "js-cookie": "^2.1.4",
     "path": "^0.12.7",
-    "redux": "^3.7.2",
-    "redux-thunk": "^2.3.0"
+    "redux": "*",
+    "redux-thunk": "*"
   },
   "devDependencies": {
     "@types/jest": "^23.3.1",
@@ -54,8 +54,8 @@
     "typescript": "^3.3.4000"
   },
   "peerDependencies": {
-    "redux-thunk": ">= 2 < 3",
-    "redux": ">= 3 < 4"
+    "redux-thunk": "*",
+    "redux": "*"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
* Ignore vscode directory
* Update npmignore to mirror gitignore (minus the dist directory)
* Unpin peer dependencies (no usage of breaking changes)