### PR TITLE
Set generic types for requests and reducers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - 6.11.5
 
 install:
-  - npm install
+  - npm ci
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 
 language: node_js
 
-node_js:
-  - 6.11.5
-
 install:
   - npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5268,9 +5268,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.4000",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
-      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5268,9 +5268,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
-      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
+      "version": "3.3.4000",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^24.0.2",
     "tslint": "^5.11.0",
     "tslint-config-dabapps": "github:dabapps/tslint-config-dabapps#v0.5.3",
-    "typescript": "^3.8.2"
+    "typescript": "^3.3.4000"
   },
   "peerDependencies": {
     "redux-thunk": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-requests",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Library for simple redux requests",
   "main": "dist/js/index.js",
   "directories": {},

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^24.0.2",
     "tslint": "^5.11.0",
     "tslint-config-dabapps": "github:dabapps/tslint-config-dabapps#v0.5.3",
-    "typescript": "^3.3.4000"
+    "typescript": "^3.8.2"
   },
   "peerDependencies": {
     "redux-thunk": "*",

--- a/src/ts/actions.ts
+++ b/src/ts/actions.ts
@@ -47,7 +47,7 @@ function serializeMeta(meta: Partial<ExtraMeta>, options: Options): ExtraMeta {
   };
 }
 
-export function requestWithConfig<T = void>(
+export function requestWithConfig<T = {}>(
   actionSet: AsyncActionSet,
   axoisConfig: AxiosRequestConfig,
   options: Options = {},
@@ -60,7 +60,7 @@ export function requestWithConfig<T = void>(
     dispatch(setRequestState(actionSet, 'REQUEST', null, meta.tag));
 
     return apiRequest<T>(axoisConfig).then(
-      (response: AxiosResponse) => {
+      (response: AxiosResponse<T>) => {
         dispatch({
           type: actionSet.SUCCESS,
           payload: response,
@@ -90,7 +90,7 @@ export function requestWithConfig<T = void>(
   };
 }
 
-export function request<T = void>(
+export function request<T = {}>(
   actionSet: AsyncActionSet,
   url: string,
   method: UrlMethod,

--- a/src/ts/actions.ts
+++ b/src/ts/actions.ts
@@ -47,7 +47,7 @@ function serializeMeta(meta: Partial<ExtraMeta>, options: Options): ExtraMeta {
   };
 }
 
-export function requestWithConfig(
+export function requestWithConfig<T = void>(
   actionSet: AsyncActionSet,
   axoisConfig: AxiosRequestConfig,
   options: Options = {},
@@ -59,7 +59,7 @@ export function requestWithConfig(
     dispatch({ type: actionSet.REQUEST, meta });
     dispatch(setRequestState(actionSet, 'REQUEST', null, meta.tag));
 
-    return apiRequest(axoisConfig).then(
+    return apiRequest<T>(axoisConfig).then(
       (response: AxiosResponse) => {
         dispatch({
           type: actionSet.SUCCESS,
@@ -90,7 +90,7 @@ export function requestWithConfig(
   };
 }
 
-export function request(
+export function request<T = void>(
   actionSet: AsyncActionSet,
   url: string,
   method: UrlMethod,
@@ -98,7 +98,7 @@ export function request(
   params: RequestParams = {}
 ) {
   const { headers, tag, metaData, shouldRethrow } = params;
-  return requestWithConfig(
+  return requestWithConfig<T>(
     actionSet,
     { url, method, data, headers },
     { tag, shouldRethrow },

--- a/src/ts/reducers.ts
+++ b/src/ts/reducers.ts
@@ -7,7 +7,7 @@ import {
   SetRequestStatePayload,
 } from './types';
 
-export function responsesReducer<T = {}>(
+export function responsesReducer<T = any>(
   state: ResponsesReducerState<T> = {},
   action: AnyAction
 ): ResponsesReducerState<T> {

--- a/src/ts/reducers.ts
+++ b/src/ts/reducers.ts
@@ -7,7 +7,7 @@ import {
   SetRequestStatePayload,
 } from './types';
 
-export function responsesReducer<T = any>(
+export function responsesReducer<T = {}>(
   state: ResponsesReducerState<T> = {},
   action: AnyAction
 ): ResponsesReducerState<T> {

--- a/src/ts/reducers.ts
+++ b/src/ts/reducers.ts
@@ -7,10 +7,10 @@ import {
   SetRequestStatePayload,
 } from './types';
 
-export function responsesReducer(
-  state: ResponsesReducerState = {},
+export function responsesReducer<T = any>(
+  state: ResponsesReducerState<T> = {},
   action: AnyAction
-): ResponsesReducerState {
+): ResponsesReducerState<T> {
   switch (action.type) {
     case REQUEST_STATE:
       if (isFSA(action)) {

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -13,12 +13,12 @@ export type AsyncActionSet = Readonly<{
   SUCCESS: string;
 }>;
 
-export type ResponseState<T> = Readonly<{
+export type ResponseState<T = {}> = Readonly<{
   requestState: RequestStates | null;
   data: AxiosResponse<T> | AxiosError | null;
 }>;
 
-export type ResponsesReducerState<T> = Dict<Dict<ResponseState<T>>>;
+export type ResponsesReducerState<T = {}> = Dict<Dict<ResponseState<T>>>;
 
 export type SetRequestStatePayload = Readonly<{
   actionSet: AsyncActionSet;

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -13,12 +13,12 @@ export type AsyncActionSet = Readonly<{
   SUCCESS: string;
 }>;
 
-export type ResponseState = Readonly<{
+export type ResponseState<T> = Readonly<{
   requestState: RequestStates | null;
-  data: AxiosResponse<any> | AxiosError | null;
+  data: AxiosResponse<T> | AxiosError | null;
 }>;
 
-export type ResponsesReducerState = Dict<Dict<ResponseState>>;
+export type ResponsesReducerState<T> = Dict<Dict<ResponseState<T>>>;
 
 export type SetRequestStatePayload = Readonly<{
   actionSet: AsyncActionSet;

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -18,7 +18,7 @@ export type ResponseState<T = {}> = Readonly<{
   data: AxiosResponse<T> | AxiosError | null;
 }>;
 
-export type ResponsesReducerState<T = {}> = Dict<Dict<ResponseState<T>>>;
+export type ResponsesReducerState<T = any> = Dict<Dict<ResponseState<T>>>;
 
 export type SetRequestStatePayload = Readonly<{
   actionSet: AsyncActionSet;

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -26,6 +26,7 @@ export function makeAsyncActionSet(actionName: string): AsyncActionSet {
   };
 }
 
+
 export function formatQueryParams<T>(params?: Dict<T>): string {
   if (!params) {
     return '';
@@ -36,7 +37,7 @@ export function formatQueryParams<T>(params?: Dict<T>): string {
     .filter(
       ([, value]: [string, T]) => value !== null && typeof value !== 'undefined'
     )
-    .map(([key, value]) => [key, `${value}`]);
+    .map(([key, value]) => [key, value.toString()]);
 
   if (!filteredPairs || !filteredPairs.length) {
     return '';

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -45,7 +45,7 @@ export function formatQueryParams<T>(params?: Dict<T>): string {
   return '?' + filteredPairs.map(([key, value]) => `${key}=${value}`).join('&');
 }
 
-export function apiRequest<T = void>(
+export function apiRequest<T = {}>(
   options: AxiosRequestConfig
 ): AxiosPromise<T> {
   const combinedHeaders = {

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -36,7 +36,7 @@ export function formatQueryParams<T>(params?: Dict<T>): string {
     .filter(
       ([, value]: [string, T]) => value !== null && typeof value !== 'undefined'
     )
-    .map(([key, value]) => [key, value.toString()]);
+    .map(([key, value]) => [key, `${value}`]);
 
   if (!filteredPairs || !filteredPairs.length) {
     return '';
@@ -45,7 +45,9 @@ export function formatQueryParams<T>(params?: Dict<T>): string {
   return '?' + filteredPairs.map(([key, value]) => `${key}=${value}`).join('&');
 }
 
-export function apiRequest(options: AxiosRequestConfig): AxiosPromise {
+export function apiRequest<T = void>(
+  options: AxiosRequestConfig
+): AxiosPromise<T> {
   const combinedHeaders = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
@@ -82,39 +84,39 @@ export function apiRequest(options: AxiosRequestConfig): AxiosPromise {
   return axios(config);
 }
 
-function getResponseState(
-  state: ResponsesReducerState,
+function getResponseState<T>(
+  state: ResponsesReducerState<T>,
   actionSet: AsyncActionSet,
   tag?: string
-): ResponseState {
+): ResponseState<T> {
   return (state[actionSet.REQUEST] || {})[tag || ''] || {};
 }
-export function isPending(
-  state: ResponsesReducerState,
+export function isPending<T>(
+  state: ResponsesReducerState<T>,
   actionSet: AsyncActionSet,
   tag?: string
 ): boolean {
   return getResponseState(state, actionSet, tag).requestState === 'REQUEST';
 }
 
-export function hasFailed(
-  state: ResponsesReducerState,
+export function hasFailed<T>(
+  state: ResponsesReducerState<T>,
   actionSet: AsyncActionSet,
   tag?: string
 ): boolean {
   return getResponseState(state, actionSet, tag).requestState === 'FAILURE';
 }
 
-export function hasSucceeded(
-  state: ResponsesReducerState,
+export function hasSucceeded<T>(
+  state: ResponsesReducerState<T>,
   actionSet: AsyncActionSet,
   tag?: string
 ): boolean {
   return getResponseState(state, actionSet, tag).requestState === 'SUCCESS';
 }
 
-export function anyPending(
-  state: ResponsesReducerState,
+export function anyPending<T>(
+  state: ResponsesReducerState<T>,
   actionSets: ReadonlyArray<AsyncActionSet | [AsyncActionSet, string]>
 ): boolean {
   return actionSets.some(actionSet => {
@@ -131,8 +133,8 @@ function isAxiosError(data: Dict<any>): data is AxiosError {
   return 'config' in data && 'name' in data && 'message' in data;
 }
 
-export function getErrorData(
-  state: ResponsesReducerState,
+export function getErrorData<T>(
+  state: ResponsesReducerState<T>,
   actionSet: AsyncActionSet,
   tag?: string
 ): AxiosError | null {

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -26,7 +26,9 @@ export function makeAsyncActionSet(actionName: string): AsyncActionSet {
   };
 }
 
-export function formatQueryParams<T>(params?: Dict<T>): string {
+export function formatQueryParams(
+  params?: Dict<string | number | boolean | null | undefined>
+): string {
   if (!params) {
     return '';
   }
@@ -34,7 +36,10 @@ export function formatQueryParams<T>(params?: Dict<T>): string {
   const asPairs = asEntries(params);
   const filteredPairs = asPairs
     .filter(
-      ([, value]: [string, T]) => value !== null && typeof value !== 'undefined'
+      <T>(
+        tuple: [string, T]
+      ): tuple is [string, Exclude<T, undefined | null>] =>
+        tuple[1] !== null && typeof tuple[1] !== 'undefined'
     )
     .map(([key, value]) => [key, value.toString()]);
 

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -26,7 +26,6 @@ export function makeAsyncActionSet(actionName: string): AsyncActionSet {
   };
 }
 
-
 export function formatQueryParams<T>(params?: Dict<T>): string {
   if (!params) {
     return '';

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -429,7 +429,7 @@ describe('Requests', () => {
 
     describe('isPending', () => {
       it('should return true if a request is pending', () => {
-        const responsesState: ResponsesReducerState<null> = {
+        const responsesState: ResponsesReducerState<{}> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'REQUEST',
@@ -444,7 +444,7 @@ describe('Requests', () => {
 
     describe('hasFailed', () => {
       it('should return true if a request has failed', () => {
-        const responsesState: ResponsesReducerState<null> = {
+        const responsesState: ResponsesReducerState<{}> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'FAILURE',
@@ -460,7 +460,7 @@ describe('Requests', () => {
 
     describe('hasSucceeded', () => {
       it('should return true if a request has succeeded', () => {
-        const responsesState: ResponsesReducerState<null> = {
+        const responsesState: ResponsesReducerState<{}> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'SUCCESS',
@@ -476,7 +476,7 @@ describe('Requests', () => {
 
     describe('anyPending', () => {
       it('should return true if any requests are pending', () => {
-        const responsesState: ResponsesReducerState<null> = {
+        const responsesState: ResponsesReducerState<{}> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'REQUEST',
@@ -491,7 +491,7 @@ describe('Requests', () => {
           ])
         ).toBe(true);
 
-        const responsesState2: ResponsesReducerState<null> = {
+        const responsesState2: ResponsesReducerState<{}> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'SUCCESS',
@@ -506,7 +506,7 @@ describe('Requests', () => {
           ])
         ).toBe(false);
 
-        const responsesState3: ResponsesReducerState<null> = {
+        const responsesState3: ResponsesReducerState<{}> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'SUCCESS',

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -429,7 +429,7 @@ describe('Requests', () => {
 
     describe('isPending', () => {
       it('should return true if a request is pending', () => {
-        const responsesState: ResponsesReducerState = {
+        const responsesState: ResponsesReducerState<null> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'REQUEST',
@@ -444,7 +444,7 @@ describe('Requests', () => {
 
     describe('hasFailed', () => {
       it('should return true if a request has failed', () => {
-        const responsesState: ResponsesReducerState = {
+        const responsesState: ResponsesReducerState<null> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'FAILURE',
@@ -460,7 +460,7 @@ describe('Requests', () => {
 
     describe('hasSucceeded', () => {
       it('should return true if a request has succeeded', () => {
-        const responsesState: ResponsesReducerState = {
+        const responsesState: ResponsesReducerState<null> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'SUCCESS',
@@ -476,7 +476,7 @@ describe('Requests', () => {
 
     describe('anyPending', () => {
       it('should return true if any requests are pending', () => {
-        const responsesState: ResponsesReducerState = {
+        const responsesState: ResponsesReducerState<null> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'REQUEST',
@@ -491,7 +491,7 @@ describe('Requests', () => {
           ])
         ).toBe(true);
 
-        const responsesState2: ResponsesReducerState = {
+        const responsesState2: ResponsesReducerState<null> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'SUCCESS',
@@ -506,7 +506,7 @@ describe('Requests', () => {
           ])
         ).toBe(false);
 
-        const responsesState3: ResponsesReducerState = {
+        const responsesState3: ResponsesReducerState<null> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'SUCCESS',
@@ -534,7 +534,7 @@ describe('Requests', () => {
 
     describe('getErrorData', () => {
       it('should return error data for a failed request', () => {
-        const responsesState: ResponsesReducerState = {
+        const responsesState: ResponsesReducerState<{ error: string }> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'REQUEST',
@@ -557,7 +557,7 @@ describe('Requests', () => {
         };
         expect(getErrorData(responsesState, ACTION_SET, 'tag')).toBe(null);
 
-        const responsesState2: ResponsesReducerState = {
+        const responsesState2: ResponsesReducerState<{ error: string }> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'FAILURE',
@@ -587,7 +587,7 @@ describe('Requests', () => {
       });
 
       it('should skip non-error data', () => {
-        const responsesState: ResponsesReducerState = {
+        const responsesState: ResponsesReducerState<{ error: string }> = {
           [ACTION_SET.REQUEST]: {
             tag: {
               requestState: 'FAILURE',

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -164,7 +164,7 @@ describe('Requests', () => {
           {},
           { headers: { header1: 'blah' }, tag: 'tag' }
         );
-        myRequest = headerThunk(dispatch) as AxiosMock;
+        myRequest = (headerThunk(dispatch) as unknown) as AxiosMock;
         expect(
           myRequest.params.headers && myRequest.params.headers.header1
         ).toBe('blah');
@@ -175,7 +175,7 @@ describe('Requests', () => {
       });
 
       it('should dispatch request actions', () => {
-        myRequest = thunk(dispatch) as AxiosMock;
+        myRequest = (thunk(dispatch) as unknown) as AxiosMock;
 
         expect(dispatch).toHaveBeenCalledWith({
           meta: {
@@ -190,21 +190,21 @@ describe('Requests', () => {
       });
 
       it('should normalize URLs', () => {
-        myRequest = request(ACTION_SET, '/api//llama/', METHOD)(
+        myRequest = (request(ACTION_SET, '/api//llama/', METHOD)(
           dispatch
-        ) as AxiosMock;
+        ) as unknown) as AxiosMock;
         expect(myRequest.params.url).toEqual('/api/llama/');
       });
 
       it('should not normalize absolute URLs', () => {
-        myRequest = request(ACTION_SET, 'http://www.test.com', METHOD)(
+        myRequest = (request(ACTION_SET, 'http://www.test.com', METHOD)(
           dispatch
-        ) as AxiosMock;
+        ) as unknown) as AxiosMock;
         expect(myRequest.params.url).toEqual('http://www.test.com');
       });
 
       it('should dispatch success actions', () => {
-        myRequest = thunk(dispatch) as AxiosMock;
+        myRequest = (thunk(dispatch) as unknown) as AxiosMock;
         myRequest.success({
           data: 'llama',
         });
@@ -223,7 +223,7 @@ describe('Requests', () => {
       });
 
       it('should dispatch failure actions', () => {
-        myRequest = thunk(dispatch) as AxiosMock;
+        myRequest = (thunk(dispatch) as unknown) as AxiosMock;
         const result = myRequest.failure({
           response: {
             data: 'llama',
@@ -287,17 +287,17 @@ describe('Requests', () => {
         expect(typeof thunk).toBe('function');
       });
       it('should set url', () => {
-        const myRequest = requestWithConfig(ACTION_SET, {
+        const myRequest = (requestWithConfig(ACTION_SET, {
           url: 'http://www.test.com',
           method: METHOD,
-        })(dispatch) as AxiosMock;
+        })(dispatch) as unknown) as AxiosMock;
         expect(myRequest.params.url).toEqual('http://www.test.com');
       });
       it('should set method', () => {
-        const myRequest = requestWithConfig(ACTION_SET, {
+        const myRequest = (requestWithConfig(ACTION_SET, {
           url: 'http://www.test.com',
           method: METHOD,
-        })(dispatch) as AxiosMock;
+        })(dispatch) as unknown) as AxiosMock;
         expect(myRequest.params.method).toEqual(METHOD);
       });
       it('should take extra meta but not override the tag', () => {


### PR DESCRIPTION
- Update typescript to the latest version as the previous version could not handle generics as well
- Update requests to take a generic parameter which will type the axios return
- Default return is void, might not be necessary to set a default as to force the developer to always set an explicit return type.