### PR TITLE
Make getResponseState public

### DIFF
--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -90,7 +90,7 @@ export function apiRequest<T = {}>(
   return axios(config);
 }
 
-function getResponseState<T>(
+export function getResponseState<T>(
   state: ResponsesReducerState<T>,
   actionSet: AsyncActionSet,
   tag?: string


### PR DESCRIPTION
I find that being able to access this state directly when you have simple components such as a read-only detail or list view is very concise.

You can simply dispatch the request when the component has mounted, monitor its loading and failure states then finally access its data safely when the requests have finished.